### PR TITLE
Cardinality refactor

### DIFF
--- a/src/cli/cardinality.cpp
+++ b/src/cli/cardinality.cpp
@@ -5,14 +5,19 @@
 
 int main() {
     ICardinality<std::string> *counter_ptr = new DummyCounter<std::string>();
-
+    ICardinality<std::string> *LogLog_ptr = new LogLog<std::string>(7);
     std::string s;
-    while(std::cin >> s)
+
+    while(std::cin >> s) {
         counter_ptr->offer(s);
+        LogLog_ptr->offer(s);
+    }
 
-    std::cout << "All the stream procesed..." << std::endl;
 
-    std::cout << counter_ptr->cardinality() << ' ' << counter_ptr->elementsOffered() << std::endl;
+    std::cout << "DummyCounter: " << counter_ptr->cardinality() << ' ' << counter_ptr->elementsOffered() \
+        << ' ' << counter_ptr->cardinality()/counter_ptr->cardinality() << std::endl;
+    std::cout << "LogLog: " << LogLog_ptr->cardinality() << ' ' << LogLog_ptr->elementsOffered() \
+        << ' ' << counter_ptr->cardinality()/(double)LogLog_ptr->cardinality() << std::endl;
 
     return 0;
 }

--- a/src/cli/cardinality.cpp
+++ b/src/cli/cardinality.cpp
@@ -4,7 +4,7 @@
 #include "../stream/cardinality/Cardinality.hpp"
 
 int main() {
-    ICardinality<std::string> *counter_ptr = new LogLog<std::string>();
+    ICardinality<std::string> *counter_ptr = new DummyCounter<std::string>();
 
     std::string s;
     while(std::cin >> s)

--- a/src/hash/MurmurHash.hpp
+++ b/src/hash/MurmurHash.hpp
@@ -5,13 +5,19 @@
 #ifndef LIBSTREAM_MURMURHASH_HPP
 #define LIBSTREAM_MURMURHASH_HPP
 #include "IHasher.hpp"
-
+#include "utils.cpp"
 template <typename T>
 class MurmurHash : public IHasher<T> {
 
-    int seed;
+    std::uint64_t seed;
 public:
-    MurmurHash(int _seed) : seed{_seed} {}
+
+    MurmurHash() {
+        this->seed = uint64RandomNumber();
+    }
+
+    MurmurHash(std::uint64_t _seed) : seed{_seed} {}
+
     std::uint32_t hash(const std::string &str) {
         return hash(str, str.size());
     }
@@ -71,7 +77,52 @@ public:
     }
 
     std::uint64_t hash64(const std::string &str, std::size_t length) {
-        return hash64(str, str.size());
+        std::uint64_t m = 0xc6a4a7935bd1e995L;
+        int r = 47;
+
+        std::uint64_t h = (seed & 0xffffffffl) ^ (length * m);
+
+        int length8 = length / 8;
+
+        for (int i = 0; i < length8; i++) {
+            int i8 = i * 8;
+            std::uint64_t k = ((std::uint64_t) str[i8 + 0] & 0xff) + (((std::uint64_t) str[i8 + 1] & 0xff) << 8)
+                     + (((std::uint64_t) str[i8 + 2] & 0xff) << 16) + (((std::uint64_t) str[i8 + 3] & 0xff) << 24)
+                     + (((std::uint64_t) str[i8 + 4] & 0xff) << 32) + (((std::uint64_t) str[i8 + 5] & 0xff) << 40)
+                     + (((std::uint64_t) str[i8 + 6] & 0xff) << 48) + (((std::uint64_t) str[i8 + 7] & 0xff) << 56);
+
+            k *= m;
+            k ^= k >> r;
+            k *= m;
+
+            h ^= k;
+            h *= m;
+        }
+
+        switch (length % 8) {
+            case 7:
+                h ^= (std::uint64_t) (str[(length & ~7) + 6] & 0xff) << 48;
+            case 6:
+                h ^= (std::uint64_t) (str[(length & ~7) + 5] & 0xff) << 40;
+            case 5:
+                h ^= (std::uint64_t) (str[(length & ~7) + 4] & 0xff) << 32;
+            case 4:
+                h ^= (std::uint64_t) (str[(length & ~7) + 3] & 0xff) << 24;
+            case 3:
+                h ^= (std::uint64_t) (str[(length & ~7) + 2] & 0xff) << 16;
+            case 2:
+                h ^= (std::uint64_t) (str[(length & ~7) + 1] & 0xff) << 8;
+            case 1:
+                h ^= (std::uint64_t) (str[length & ~7] & 0xff);
+                h *= m;
+        }
+        ;
+
+        h ^= h >> r;
+        h *= m;
+        h ^= h >> r;
+
+        return h;
     }
 };
 

--- a/src/hash/utils.cpp
+++ b/src/hash/utils.cpp
@@ -1,0 +1,26 @@
+//
+// Created by Jordi Sanabria on 9/2/16.
+//
+
+#ifndef LIBSTREAM_HASH_UTILS_HPP
+#define LIBSTREAM_HASH_UTILS_HPP
+
+#include<stdlib.h>
+#include<time.h>
+
+std::uint64_t uint64RandomNumber() {
+
+    std::uint64_t  randomNumber;
+
+    srand (time(NULL));
+
+    randomNumber  = (std::uint64_t) rand();
+    randomNumber |= (std::uint64_t) rand() << 15;
+    randomNumber |= (std::uint64_t) rand() << 30;
+    randomNumber |= (std::uint64_t) rand() << 45;
+    randomNumber |= (std::uint64_t) rand() << 60;
+
+    return randomNumber;
+}
+
+#endif //LIBSTREAM_HASH_UTILS_HPP

--- a/src/stream/cardinality/DummyCounter.hpp
+++ b/src/stream/cardinality/DummyCounter.hpp
@@ -30,27 +30,38 @@ class DummyCounter : public ICardinality<T> {
 
 public:
 
+    /*
+     * TODO: Description
+     */
     DummyCounter() : n{0} {}
 
-    bool offerHashed(std::uint64_t element) {
-        throw "Dummy Counter does't work with unit64_t type";
+    /*
+     * TODO: Description
+     */
+    bool offerHash(std::uint64_t element) {
+        throw "Don't use offerHash with the Dummy Counter. Instead use offer";
     }
 
-    bool offerHashed(T element) {
-        ++n;
-        int old_size = itemSet.size();
-        itemSet.insert(element);
-        return (itemSet.size() != old_size);
-    }
-
+    /*
+     * TODO: Description
+     */
     std::uint64_t cardinality() {
         return itemSet.size();
     }
 
+    /*
+     * TODO: Description
+     */
     bool offer(T o) {
-        return offerHashed(o);
+        ++n;
+        int old_size = itemSet.size();
+        itemSet.insert(o);
+        return (itemSet.size() != old_size);
     }
 
+    /*
+     * TODO: Description
+     */
     std::uint64_t elementsOffered() {
         return n;
     }

--- a/src/stream/cardinality/DummyCounter.hpp
+++ b/src/stream/cardinality/DummyCounter.hpp
@@ -12,35 +12,46 @@
 template <typename T>
 class DummyCounter : public ICardinality<T> {
 
+    /*
+     * n: keeps the counter of how many elements has been offered (with repetitions)
+     */
+    uint64_t n;
 
-    int n;
-    std::unordered_set<std::size_t> itemSet;
-    std::hash<T> hasher;
-    const int MAX_SET_SIZE = 1 << 16;
+    /*
+     * itemSet:  keeps all the elements that has been offered (without repetitions)
+     */
+    std::unordered_set<T> itemSet;
 
-
+    /*
+    * MAX_SET_SIZE:  Upperbound for the itemSet
+    */
+    // Remember x << y with y > 32 is has an undefined behavior
+    const int MAX_SET_SIZE = 1 << 31;
 
 public:
 
     DummyCounter() : n{0} {}
 
-    bool offerHashed(std::size_t hashedValue) {
+    bool offerHashed(std::uint64_t element) {
+        throw "Dummy Counter does't work with unit64_t type";
+    }
+
+    bool offerHashed(T element) {
         ++n;
         int old_size = itemSet.size();
-        itemSet.insert(hashedValue);
+        itemSet.insert(element);
         return (itemSet.size() != old_size);
     }
 
-    std::size_t cardinality() {
+    std::uint64_t cardinality() {
         return itemSet.size();
     }
 
     bool offer(T o) {
-        std::size_t x =  hasher(o);
-        return offerHashed(x);
+        return offerHashed(o);
     }
 
-    std::size_t elementsOffered() {
+    std::uint64_t elementsOffered() {
         return n;
     }
 };

--- a/src/stream/cardinality/ICardinality.hpp
+++ b/src/stream/cardinality/ICardinality.hpp
@@ -1,11 +1,10 @@
 //
-// Created by jordi on 8/14/2016.
+// Created by Jordi Montes Sanabria on 8/14/2016.
 //
 
 #ifndef LIBSTREAM_ICARDINALITY_H
 #define LIBSTREAM_ICARDINALITY_H
 
-#include <cstddef> /* size_t */
 
 
 template <typename T>
@@ -14,7 +13,7 @@ public:
 
     /**
     * @param o stream element
-    * @return false if the value returned by cardinality() is unaffected by the appearance of o in the stream.
+    * @return false if the value returned by the cardinality() is unaffected by the appearance of o in the stream.
     */
     virtual bool offer(T o) = 0;
 
@@ -24,12 +23,12 @@ public:
      * @param hashedInt - the hash of the item to offer to the estimator
      * @return false if the value returned by cardinality() is unaffected by the appearance of hashedInt in the stream
      */
-    virtual bool offerHashed(std::uint32_t hashedInt) = 0;
+    virtual bool offerHashed(std::uint64_t hashedInt) = 0;
 
     /**
      * @return the number of unique elements in the stream or an estimate thereof
      */
-    virtual std::uint32_t cardinality() = 0;
+    virtual std::uint64_t cardinality() = 0;
 
     /**
      * How many elements has it processed

--- a/src/stream/cardinality/ICardinality.hpp
+++ b/src/stream/cardinality/ICardinality.hpp
@@ -23,7 +23,7 @@ public:
      * @param hashedInt - the hash of the item to offer to the estimator
      * @return false if the value returned by cardinality() is unaffected by the appearance of hashedInt in the stream
      */
-    virtual bool offerHashed(std::uint64_t hashedInt) = 0;
+    virtual bool offerHash(std::uint64_t hashValue) = 0;
 
     /**
      * @return the number of unique elements in the stream or an estimate thereof


### PR DESCRIPTION
All the interface changed.
- Now is more generic.
- Cardinality programs use hashers of 32 and 64 bits.
- DummyCounter and LogLog algorithms implemented and working.
- CLI: cardinality program added (DummyCounter and LogLog for now).
